### PR TITLE
cert-transparency: fix chrome failing to read command-line file

### DIFF
--- a/src/interceptors/android/adb-commands.ts
+++ b/src/interceptors/android/adb-commands.ts
@@ -290,7 +290,8 @@ export async function setChromeFlags(
             ${
                 chromeFlagsLocations.map((flagsFilePath) => `
             echo "${flagsFileContent}" > "${flagsFilePath}"
-            chmod 744 "${flagsFilePath}"`
+            chmod 744 "${flagsFilePath}"
+            chcon "u:object_r:shell_data_file:s0" "${flagsFilePath}"`
                 ).join('\n')
             }
 


### PR DESCRIPTION
fixes https://github.com/httptoolkit/httptoolkit/issues/325

Turns out Chrome tries to read the `chrome-command-line` file from `/data/local/` (unless ROM is `userdebug` and `/data/local/tmp/chrome-command-line` is present - [ref](https://source.chromium.org/chromium/chromium/src/+/main:base/android/java/src/org/chromium/base/CommandLineInitUtil.java;l=53;drc=b9539659f98e35ba63b84c1adf299a7a2590e07e?q=%2Fdata%2Flocal%2F&ss=chromium%2Fchromium%2Fsrc&start=101)) and fails due to the following SELinux error:
```log
avc: denied { open } for path="/data/local/chrome-command-line" dev="mmcblk0p69" ino=2891798 scontext=u:r:untrusted_app:s0:c141,c256,c512,c768 tcontext=u:object_r:system_data_file:s0 tclass=file permissive=0 app=com.android.chrome
```

This only happens when SELinux is Enforcing and simply updating SELinux context of `/data/local/tmp/chrome-command-line` to `u:object_r:shell_data_file:s0` (which is the context of files in `/data/local/tmp/`) should solve this issue.