### PR TITLE
Update php

### DIFF
--- a/overrides/path/php
+++ b/overrides/path/php
@@ -8,8 +8,8 @@ PATH="`dirname "$0"`:$PATH"
 
 # Strip out our PHP_INI_SCAN_DIR - if this file has been run succesfully, then it's not necessary,
 # and it can cause problems (since it overrides any default scan directories configured)
-export PHP_INI_SCAN_DIR="${PHP_INI_SCAN_DIR//:`echo $HTTP_TOOLKIT_OVERRIDE_PATH/php`/}"
-export PHP_INI_SCAN_DIR="${PHP_INI_SCAN_DIR//`echo $HTTP_TOOLKIT_OVERRIDE_PATH/php`/}"
+export PHP_INI_SCAN_DIR="${PHP_INI_SCAN_DIR//:`echo $HTTP_TOOLKIT_OVERRIDE_PATH/`php/}"
+export PHP_INI_SCAN_DIR="${PHP_INI_SCAN_DIR//`echo $HTTP_TOOLKIT_OVERRIDE_PATH/`php/}"
 if [ -z "$PHP_INI_SCAN_DIR" ]; then
     unset PHP_INI_SCAN_DIR
 fi


### PR DESCRIPTION
fix of the error:

/Applications/HTTP Toolkit.app/Contents/Resources/httptoolkit-server/overrides/path/php: line 11: bad substitution: no closing "`" in `echo $HTTP_TOOLKIT_OVERRIDE_PATH