### PR TITLE
Fix PHP syntax error in override.ini

### DIFF
--- a/overrides/php/php-httptoolkit-override.ini
+++ b/overrides/php/php-httptoolkit-override.ini
@@ -1,22 +1,22 @@
-# Make OpenSSL trust us
+; Make OpenSSL trust us
 openssl.cafile=${SSL_CERT_FILE}
-# Make cURL trust us
+; Make cURL trust us
 curl.cainfo=${SSL_CERT_FILE}
-# Prepend a script that enables the proxy
+; Prepend a script that enables the proxy
 auto_prepend_file=${HTTP_TOOLKIT_OVERRIDE_PATH}/php/prepend.php
 
-# Intercepting PHP using this file via PHP_INI_SCAN_DIR isn't a perfect solution. It's better
-# to use the 'php' wrapper (overrides/path/php) which sets this configuration, because when
-# PHP_INI_SCAN_DIR is left blank it defaults to a system config directory, and overriding this
-# means that is not loaded.
-# Unfortunately, it's not always possible to inject the 'php' wrapper where we need it, due to
-# how PHP is often launched (managed by another process, not launched & injectable by HTTP Toolkit).
-# This is a fallback solution for that case that seems to work well in practice.
+; Intercepting PHP using this file via PHP_INI_SCAN_DIR isn't a perfect solution. It's better
+; to use the 'php' wrapper (overrides/path/php) which sets this configuration, because when
+; PHP_INI_SCAN_DIR is left blank it defaults to a system config directory, and overriding this
+; means that is not loaded.
+; Unfortunately, it's not always possible to inject the 'php' wrapper where we need it, due to
+; how PHP is often launched (managed by another process, not launched & injectable by HTTP Toolkit).
+; This is a fallback solution for that case that seems to work well in practice.
 
-# Where this doesn't work, you may be able to replace the relevant env vars above and place this
-# file directly into your PHP_INI_SCAN_DIR directory (run php --ini to find this).
+; Where this doesn't work, you may be able to replace the relevant env vars above and place this
+; file directly into your PHP_INI_SCAN_DIR directory (run php --ini to find this).
 
-# (In future, we could consider more complicated fixes: e.g. a prepend script that launches a PHP
-# subprocess which runs with the default configuration, just explicitly overridden by CLI args.
-# That would have some performance implications, but probably nothing notable in dev. Not worthwhile
-# for now unless this causes serious problems though)
+; (In future, we could consider more complicated fixes: e.g. a prepend script that launches a PHP
+; subprocess which runs with the default configuration, just explicitly overridden by CLI args.
+; That would have some performance implications, but probably nothing notable in dev. Not worthwhile
+; for now unless this causes serious problems though)


### PR DESCRIPTION
Fixes httptoolkit/httptoolkit#433 by replacing # comment notation with ; notation instead.