### PR TITLE
fixed injecting script for devices with APEX

### DIFF
--- a/src/interceptors/android/adb-commands.ts
+++ b/src/interceptors/android/adb-commands.ts
@@ -310,10 +310,11 @@ export async function injectSystemCertificate(
 
                 # Apps inherit the Zygote's mounts at startup, so we inject here to ensure all newly
                 # started apps will see these certs straight away:
-                for Z_PID in "$ZYGOTE_PID $ZYGOTE64_PID"; do
+                for Z_PID in "$ZYGOTE_PID" "$ZYGOTE64_PID"; do
                     # We use 'echo' below to trim spaces
-                    nsenter --mount=/proc/$(echo $Z_PID)/ns/mnt -- \
-                        /bin/mount --bind /system/etc/security/cacerts /apex/com.android.conscrypt/cacerts
+                    if [ -n "$Z_PID" ]; then
+                        nsenter --mount=/proc/$(echo $Z_PID)/ns/mnt -- \
+                            /bin/mount --bind /system/etc/security/cacerts /apex/com.android.conscrypt/cacerts
                 done
 
                 echo 'Zygote APEX certificates remounted'

--- a/src/interceptors/android/adb-commands.ts
+++ b/src/interceptors/android/adb-commands.ts
@@ -315,6 +315,7 @@ export async function injectSystemCertificate(
                     if [ -n "$Z_PID" ]; then
                         nsenter --mount=/proc/$(echo $Z_PID)/ns/mnt -- \
                             /bin/mount --bind /system/etc/security/cacerts /apex/com.android.conscrypt/cacerts
+                    fi
                 done
 
                 echo 'Zygote APEX certificates remounted'

--- a/src/interceptors/android/adb-commands.ts
+++ b/src/interceptors/android/adb-commands.ts
@@ -311,9 +311,8 @@ export async function injectSystemCertificate(
                 # Apps inherit the Zygote's mounts at startup, so we inject here to ensure all newly
                 # started apps will see these certs straight away:
                 for Z_PID in "$ZYGOTE_PID" "$ZYGOTE64_PID"; do
-                    # We use 'echo' below to trim spaces
                     if [ -n "$Z_PID" ]; then
-                        nsenter --mount=/proc/$(echo $Z_PID)/ns/mnt -- \
+                        nsenter --mount=/proc/$Z_PID/ns/mnt -- \
                             /bin/mount --bind /system/etc/security/cacerts /apex/com.android.conscrypt/cacerts
                     fi
                 done


### PR DESCRIPTION
`for Z_PID in "$ZYGOTE_PID $ZYGOTE64_PID"; do`

makes 1 string like `"829 745"` instead of array of 2 string `"829"` `"745"`

as a result we got correct 2 commands:
`nsenter --mount=/proc/829/ns/mnt --`
`nsenter --mount=/proc/845/ns/mnt --`
instead of
`nsenter --mount=/proc/829 745/ns/mnt --` with `nsenter: setns: Invalid argument` result