### PR TITLE
Added configuration to fix breaking change for latest node versions on windows cve-2024-27980

### DIFF
--- a/prepare.ts
+++ b/prepare.ts
@@ -29,7 +29,8 @@ const OVERRIDES_DIR = path.join(__dirname, 'overrides');
 
     await spawn(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['ci', '--production'], {
         cwd: path.join(OVERRIDES_DIR, 'js'),
-        stdio: 'inherit'
+        stdio: 'inherit',
+        shell: process.platform === 'win32', // Required for .cmd files due to CVE-2024-27980
     });
 
     const files: Array<{


### PR DESCRIPTION
The issue lies here: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high

cve-2024-27980 requires any time a .bat or .cmd is run using the spawn or spawnSync commands it now needs to pass in a configuration of { shell: true }.

This prevented the npm install command from running on a Windows machine.

After applying the change, npm install runs to completion. I have also tested against the node.js package-lock.json version 20.11.1 and the addition of the configuration makes no noticeable difference.