### PR TITLE
Make Android isProbablyRooted work with adb root

### DIFF
--- a/src/interceptors/android/adb-commands.ts
+++ b/src/interceptors/android/adb-commands.ts
@@ -246,11 +246,22 @@ export async function pushFile(
 }
 
 export async function isProbablyRooted(deviceClient: Adb.DeviceClient) {
-    return run(deviceClient, ['command', '-v', 'su'], {
+    let hasSu = await run(deviceClient, ['command', '-v', 'su'], {
             timeout: 500,
             skipLogging: true
         })
         .then((result) => result.includes('/su'))
+        .catch(() => false);
+
+    if (hasSu) return true;
+
+    // Check if we're currently running commands as root.
+    // Requires the user to have run `adb root` beforehand
+    return run(deviceClient, ['id'], {
+            timeout: 500,
+            skipLogging: true
+        })
+        .then((result) => result.includes('uid=0(root)'))
         .catch(() => false);
 }
 


### PR DESCRIPTION
Reuses the logic from `getRootCommand` to do root detection. 

The logic in `getRootCommand` is fairly heavy on the phone, so it might not be ideal to reuse it in this way, as `isProbablyRooted` is ran fairly often,
But I can't really find any better way doing this, as e.g. when running a LineageOS phone with rooted adb the check for `su` will fail, as it does not exist on the phone.

I considered keeping the previous check, and only running this command if that fails, but it seems nicer to reuse the logic (less nice that a file is pushed to the device on each invocation).