### PR TITLE
feat: disable https://android.clients.google.com requests in Chromium app

### DIFF
--- a/src/interceptors/chromium-based-interceptors.ts
+++ b/src/interceptors/chromium-based-interceptors.ts
@@ -61,6 +61,8 @@ const getChromiumLaunchOptions = async (
             ].join(','),
             // Avoid annoying extra network noise:
             '--disable-background-networking',
+            // Disable android.clients.google.com calls
+            '--gcm-checkin-url= --gcm-registration-url= --gcm-mcs-endpoint=',
             // Disable component update (without disabling components themselves, e.g. widevine)
             // See https://bugs.chromium.org/p/chromium/issues/detail?id=331932
             '--component-updater=url-source=http://disabled-chromium-update.localhost:0',


### PR DESCRIPTION
Linked: https://github.com/httptoolkit/httptoolkit-server/issues/205

This PR removes the https://android.clients.google.com requests made by the Chromium interceptor

Credits: https://github.com/CybercentreCanada/kangooroo/issues/43

Note that this PR isn't tested, because I didn't figure out yet how to run httptoolkit-server. But it was tested by running chromium locally with these flags (See https://github.com/httptoolkit/httptoolkit-server/issues/145#issuecomment-4352187975)