### PR TITLE
feat: disable telemetry and sponsoring requests in Firefox app

### DIFF
--- a/src/interceptors/fresh-firefox.ts
+++ b/src/interceptors/fresh-firefox.ts
@@ -128,6 +128,14 @@ abstract class Firefox implements Interceptor {
                 {
                     // Disable the noisy captive portal check requests
                     'network.captive-portal-service.enabled': false,
+                    // Disable telemetry requests
+                    'app.shield.optoutstudies.enabled': false,
+                    'datareporting.healthreport.uploadEnabled': false,
+                    'datareporting.usage.uploadEnabled': false,
+                    // Disable sponsors
+                    'browser.newtabpage.activity-stream.showSponsoredCheckboxes': false,
+                    'browser.newtabpage.activity-stream.showSponsoredTopSites': false,
+                    
 
                     // Disable some annoying tip messages
                     'browser.chrome.toolbar_tips': false,


### PR DESCRIPTION
This disables some noisy requests made on startup by Firefox :) and should not affect any feature