### PR TITLE
Add 'header-includes' matcher & matchReplaceHeaders transform (local mockttp 4.4.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "mime-types": "^2.1.27",
         "mobx": "^6.3.5",
         "mockrtc": "^0.5.1",
-        "mockttp": "^4.4.1",
+        "mockttp": "file:../mockttp/mockttp-4.4.2.tgz",
         "node-fetch": "^2.6.1",
         "node-forge": "^1.4.0",
         "node-gsettings-wrapper": "^0.5.0",
@@ -9870,9 +9870,9 @@
       }
     },
     "node_modules/mockttp": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/mockttp/-/mockttp-4.4.1.tgz",
-      "integrity": "sha512-1Ox0oZERisl1dtpAv26FsR3XMVpB4AsKJAAT1g7OerCMhIDqz8b8r/nTK562zVuOyLYttuCsLVEt4eaHYaCWUg==",
+      "version": "4.4.2",
+      "resolved": "file:../mockttp/mockttp-4.4.2.tgz",
+      "integrity": "sha512-CIgqi/11soPR/K5B+hRjYGebYGXjHhyLVhsT0BQbYpJesCX2t9aE+5HMf/Dv39Q4u7Ke06NXkIyawGMmqaiBUw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-tools/schema": "^10.0.31",
@@ -9884,7 +9884,8 @@
         "@peculiar/asn1-cms": "<2.7.0",
         "@peculiar/asn1-csr": "<2.7.0",
         "@peculiar/asn1-ecc": "<2.7.0",
-        "@peculiar/asn1-pkcs8": "^2.5.0 <2.7.0",
+        "@peculiar/asn1-pfx": "<2.7.0",
+        "@peculiar/asn1-pkcs8": "<2.7.0",
         "@peculiar/asn1-pkcs9": "<2.7.0",
         "@peculiar/asn1-rsa": "<2.7.0",
         "@peculiar/asn1-schema": "^2.3.15 <2.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9872,7 +9872,7 @@
     "node_modules/mockttp": {
       "version": "4.4.2",
       "resolved": "file:../mockttp/mockttp-4.4.2.tgz",
-      "integrity": "sha512-CIgqi/11soPR/K5B+hRjYGebYGXjHhyLVhsT0BQbYpJesCX2t9aE+5HMf/Dv39Q4u7Ke06NXkIyawGMmqaiBUw==",
+      "integrity": "sha512-bA1MPjJp4UVjh8j9YuYn/IEPF0Ou9+Hwf1aE9lPomdTM8psRrqlui2U6nHsDuBzW/tR5BKEN3FHl6Or8BYZfzg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-tools/schema": "^10.0.31",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "mime-types": "^2.1.27",
     "mobx": "^6.3.5",
     "mockrtc": "^0.5.1",
-    "mockttp": "^4.4.1",
+    "mockttp": "file:../mockttp/mockttp-4.4.2.tgz",
     "node-fetch": "^2.6.1",
     "node-forge": "^1.4.0",
     "node-gsettings-wrapper": "^0.5.0",


### PR DESCRIPTION
## Summary

Server-side support for substring header matching and header-value match-and-replace, the counterpart to the corresponding httptoolkit-ui PR.

This repoints the dependency onto a locally-built **mockttp 4.4.2** that adds:

- a **`header-includes` matcher** — matches when a given header's *value contains a substring*, evaluated server-side like every other matcher (rather than via a UI-side callback). This removes the per-request round-trip and the requirement for the UI to stay connected for matching to work.
- a **`matchReplaceHeaders` transform** — rewrites patterns *within* a header's value without replacing the whole header (e.g. one cookie inside a multi-cookie `Cookie` header).

## Changes

- `package.json` / `package-lock.json` — point mockttp at the local 4.4.2 build carrying the new matcher + transform.
- `overrides/js/package.json` — matching override bump.

## Notes

- This is a **draft**: it depends on the local mockttp build and isn't directly mergeable until that mockttp change is released. Opening it for visibility alongside the UI PR and for feedback on the matcher/transform design.
